### PR TITLE
Add Mamba package manager instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,28 @@ Internal repo for iteration on Diffusion LLMs
 
 ### Setup environment
 
+Install mamba or conda (mamba is far faster):
+
+```bash
+# For mamba: https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html#umamba-install
+"${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+
+# For conda: https://docs.conda.io/projects/conda/en/stable/user-guide/install/linux.html
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh && \
+bash miniconda.sh -b -p /opt/conda
+```
+
 Setup a conda environment and install dependencies using:
 
 ```bash
-conda env create -f requirements.yml
+micromamba env create -y -f requirements.yaml --channel-priority flexible
 ```
 
 Activate the environment:
 
 ```bash
 conda activate dllm-dev
+# OR micromamba activate dllm-dev
 ```
 
 We also include a [`setup_env.sh`](./setup_env.sh) script that can be used to set up the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+torch==2.5.1
+accelerate
+datasets
+einops
+fire
+hydra-core
+ipdb
+lm-eval
+magic-wormhole
+# Latest mosaic version compatible with torch 2.5.1 is 0.30.0
+mosaicml==0.30.0
+mosaicml-streaming
+pre-commit
+sentencepiece
+ruff
+transformers==4.52.3
+wandb

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -12,18 +12,4 @@ dependencies:
   - pytorch-cuda=12.4
   - pip
   - pip:
-      - accelerate
-      - datasets
-      - einops
-      - fire
-      - hydra-core
-      - ipdb
-      - lm-eval
-      - magic-wormhole
-      - mosaicml
-      - mosaicml-streaming
-      - pre-commit
-      - sentencepiece
-      - ruff
-      - transformers==4.52.3
-      - wandb
+      - -r requirements.txt


### PR DESCRIPTION
I found that the current conda environment ([here](https://github.com/kuleshov-group/dllm-dev/blob/b569c703fc89f8fa7051d0cf3ec2bcbbfe76bf03/requirements.yaml)) has a couple issues:

1. It's very slow to install -- it took me roughly ~25 minutes to get it to build on Lambda (single GPU w/ low network bandwidth)
2. The torch 2.5.1 package installed by conda gets uninstalled by the pip dependencies because `mosaicml` is not pinned to something at or below `v0.30.0` (the last version that support torch 2.5.1)

To help with this, I added instructions on how to use [Mamba](https://mamba.readthedocs.io/en/latest/).  It is effectively the same thing as conda and I highly recommend using that instead.  Installation on any platform is super simple:

`"${SHELL}" <(curl -L micro.mamba.pm/install.sh)`

With mamba and the changes in this PR (undoing the torch clobber), I can now build an environment in ~2.5 minutes (roughly 10x faster).